### PR TITLE
[ONGEKI] More Kamaitachi adjustments

### DIFF
--- a/src/server/routes/titles/ongeki/score-exporter.ts
+++ b/src/server/routes/titles/ongeki/score-exporter.ts
@@ -151,6 +151,12 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
 				bellLamp = "FULL BELL"
 			}
 
+			// LUNATIC stored as level 10
+			let difficulty = TACHI_DIFFICULTIES[level]
+			if (level == 10) {
+				difficulty = "LUNATIC"
+			}
+
 			const tachiScore: BatchManualScore = {
 				score: techScore,
 				noteLamp,
@@ -158,7 +164,7 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
 				platinumScore,
 				identifier: musicId.toString(),
 				matchType: "inGameID",
-				difficulty: TACHI_DIFFICULTIES[level],
+				difficulty,
 				timeAchieved
 			}
 

--- a/src/server/routes/titles/ongeki/score-exporter.ts
+++ b/src/server/routes/titles/ongeki/score-exporter.ts
@@ -1,5 +1,3 @@
-import { parse } from "date-fns"
-import { fromZonedTime, toZonedTime } from "date-fns-tz"
 import { Hono } from "hono"
 import type { RowDataPacket } from "mysql2"
 
@@ -61,7 +59,8 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
 
 		const [playlogResults] = await db.execute<RowDataPacket[]>(
 			`SELECT
-                p.userPlayDate,
+				-- UNIX_TIMESTAMP returns seconds, Tachi do be needing milliseconds
+                UNIX_TIMESTAMP(p.userPlayDate)*1000 as timeAchieved,
                 p.musicId,
                 p.level,
                 p.techScore,
@@ -81,7 +80,7 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
             FROM ongeki_score_playlog p
             WHERE user = ?
             GROUP BY p.id
-            ORDER BY p.userPlayDate DESC`,
+            ORDER BY timeAchieved DESC`,
 			[userId]
 		)
 
@@ -99,7 +98,7 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
 
 		for (const log of playlogResults) {
 			const {
-				userPlayDate,
+				timeAchieved,
 				musicId,
 				level,
 				techScore,
@@ -159,20 +158,8 @@ const OngekiKamaitachiRoutes = new Hono().get("export", async c => {
 				platinumScore,
 				identifier: musicId.toString(),
 				matchType: "inGameID",
-				difficulty: TACHI_DIFFICULTIES[level]
-			}
-
-			// Fix date parsing - ensure userPlayDate is a string
-			if (userPlayDate && typeof userPlayDate === "string") {
-				try {
-					tachiScore.timeAchieved = fromZonedTime(
-						parse(userPlayDate, "yyyy-MM-dd HH:mm:ss", toZonedTime(new Date(), "Asia/Tokyo")),
-						"Asia/Tokyo"
-					).valueOf()
-				} catch (error) {
-					// If date parsing fails, skip this field
-					console.warn(`Failed to parse date: ${userPlayDate}`)
-				}
+				difficulty: TACHI_DIFFICULTIES[level],
+				timeAchieved
 			}
 
 			if (judgeCriticalBreak !== null && judgeBreak !== null && judgeHit !== null && judgeMiss !== null) {


### PR DESCRIPTION
After importing there was a few errors, mostly for unknown songs (guessing tachi is behind a bit with versions)
LUNATIC difficulty was not being parsed from level. Added direct mapping when `level == 10`.
Also converted directly to unix ms timestamp for playtime tracking


# Tachi errors
<img width="1923" height="860" alt="image" src="https://github.com/user-attachments/assets/274216a3-3b61-4b11-aa3c-3443cf6c1e38" />


# DB level > 4
<img width="1528" height="269" alt="image" src="https://github.com/user-attachments/assets/506575f9-4a4e-4e77-a5ac-c0f727c942b6" />


# Artemis mapping
<img width="396" height="188" alt="image" src="https://github.com/user-attachments/assets/6b5cccc0-b029-43d9-9e29-6af2ab238cfa" />


# Timestamp
Here's example of playdate not importing:
<img width="1862" height="838" alt="image" src="https://github.com/user-attachments/assets/3d82bc3c-cdac-4558-99dd-c8bd6985faf3" />

And from tachi docs:
https://docs.tachi.ac/codebase/batch-manual/#format
<img width="1277" height="219" alt="image" src="https://github.com/user-attachments/assets/0ba984ac-1b2f-4c7d-a37f-3706b34c38d6" />


